### PR TITLE
[add] Uso de dotenv para carga de variables en desarrollo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # Gemfile
 source "https://rubygems.org"
 ruby '2.7.0'
+gem 'dotenv-rails', groups: [:development, :test]
 gem "sinatra", "2.0.8.1"
 gem "rack-env", "0.1.3"
 gem "rerun", "0.13.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    actionpack (6.0.2.2)
+      actionview (= 6.0.2.2)
+      activesupport (= 6.0.2.2)
+      rack (~> 2.0, >= 2.0.8)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actionview (6.0.2.2)
+      activesupport (= 6.0.2.2)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
     activemodel (6.0.2.2)
       activesupport (= 6.0.2.2)
     activerecord (6.0.2.2)
@@ -12,8 +25,15 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    builder (3.2.4)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
+    crass (1.0.6)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
+    erubi (1.9.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
@@ -23,6 +43,10 @@ GEM
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    loofah (2.4.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    method_source (1.0.0)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     multipart-post (2.1.1)
@@ -35,6 +59,19 @@ GEM
     rack-env (0.1.3)
     rack-protection (2.0.8.1)
       rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.3.0)
+      loofah (~> 2.3)
+    railties (6.0.2.2)
+      actionpack (= 6.0.2.2)
+      activesupport (= 6.0.2.2)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.20.3, < 2.0)
     rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
@@ -57,6 +94,7 @@ GEM
       activerecord (>= 3.2)
       sinatra (>= 1.0)
     telephone_number (1.4.6)
+    thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
     twilio-ruby (5.32.0)
@@ -71,6 +109,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  dotenv-rails
   pg (= 1.2.2)
   rack-env (= 0.1.3)
   rake

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,5 @@
 # config.ru
-require 'rack/env'
+require 'dotenv/load'
 require_relative './config/environment'
 require 'sidekiq'
 require 'sidekiq/web'
@@ -7,14 +7,11 @@ require 'active_support/security_utils'
 require './app'
 
 if ENV['RACK_ENV'] == 'production'
-  use Rack::Env
   redis_hash = {
     url: "redis://#{ENV['REDIS_HOST']}:#{ENV['REDIS_PORT']}",
     password: ENV['REDIS_PASSWORD'].to_s
   }
 else
-  base_path = File.expand_path(File.dirname(File.dirname(__FILE__)))
-  use Rack::Env, envfile: "#{base_path}/.env"
   redis_hash = { url: "redis://#{ENV['REDIS_HOST']}:#{ENV['REDIS_PORT']}" }
 end
 

--- a/services/twilio_sms.rb
+++ b/services/twilio_sms.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'rack/env'
+require 'dotenv/load'
 require 'twilio-ruby'
 
 class TwilioSms

--- a/workers/sms_request_worker.rb
+++ b/workers/sms_request_worker.rb
@@ -1,5 +1,5 @@
+require 'dotenv/load'
 require "sidekiq"
-require 'rack/env'
 require "net/http"
 require "json"
 require "sinatra/activerecord"


### PR DESCRIPTION
Se definen los grupos development y test para poder suprimir la gema en producción por medio de:

```bash
$ bundle install --without test development
```

Cambios aplicados:
	modified:   Gemfile
	modified:   Gemfile.lock
	modified:   config.ru
	modified:   services/twilio_sms.rb
	modified:   workers/sms_request_worker.rb